### PR TITLE
CTX-4574: Fixed LSPIN memory issue

### DIFF
--- a/bio-bodysite-prediction-nn/src/dataset.py
+++ b/bio-bodysite-prediction-nn/src/dataset.py
@@ -25,7 +25,7 @@ def loadDataset(datasetPath: Path, uniqueBodySites: dict[str, int], uniqueTaxons
             Dictionary mapping between bodysite names and their encodings
         uniqueTaxons : dict[str, int]
             Dictionary mapping between taxon ids and their encodings
-        
+
         Returns
         -------
         tf.data.Dataset -> A TensorFlow dataset objcet representing the dataset
@@ -66,7 +66,7 @@ def createBatches(
     bufferSize: int,
     batchSize: int
 ) -> tuple[tf.data.Dataset, int, tf.data.Dataset, int]:
-    
+
     trainCount = int((1 - validationSplit) * count)
     testCount = count - trainCount
 
@@ -75,7 +75,6 @@ def createBatches(
 
     trainBatches = (
         trainData
-        .cache()
         .shuffle(bufferSize)
         .batch(batchSize)
         .repeat()


### PR DESCRIPTION
tf.data.Dataset.cache was creating a cache of all samples in working memory, effectively loading the entire dataset into memory and ignoring the generator after the first epoch