### PR TITLE
Hotfix-OCR: Throw error if document is not found

### DIFF
--- a/tasks/document-ocr-fn/resources/function/function.py
+++ b/tasks/document-ocr-fn/resources/function/function.py
@@ -10,6 +10,14 @@ from ocr import performOCR
 from object_detection import runObjectDetection
 
 
+DOCUMENT_NOT_FOUND = {
+    "code": 404,
+    "body": {
+        "error": "Failed to find document on the provided image"
+    }
+}
+
+
 def response(requestData: dict[str, Any]) -> dict[str, Any]:
     modelsDir = requestData.get("model")
 
@@ -23,11 +31,11 @@ def response(requestData: dict[str, Any]) -> dict[str, Any]:
     predictedMask = detect_document.run(segmentationModel, imagePath)
     predictedMask = processMask(predictedMask)
     if predictedMask is None:
-        return functions.badRequest("Failed to determine document borders")
+        return DOCUMENT_NOT_FOUND
 
     segmentedImage = segmentImage(imagePath, predictedMask)
     if segmentedImage is None:
-        return functions.badRequest("Failed to determine document borders")
+        return DOCUMENT_NOT_FOUND
 
     bboxes, classes = runObjectDetection(segmentedImage, objDetModelWeights)
     segmentedDetections = segmentDetections(segmentedImage, bboxes)

--- a/tasks/document-ocr-fn/resources/function/function.py
+++ b/tasks/document-ocr-fn/resources/function/function.py
@@ -22,6 +22,8 @@ def response(requestData: dict[str, Any]) -> dict[str, Any]:
 
     predictedMask = detect_document.run(segmentationModel, imagePath)
     predictedMask = processMask(predictedMask)
+    if predictedMask is None:
+        return functions.badRequest("Failed to determine document borders")
 
     segmentedImage = segmentImage(imagePath, predictedMask)
     if segmentedImage is None:

--- a/tasks/document-ocr-fn/resources/function/function.py
+++ b/tasks/document-ocr-fn/resources/function/function.py
@@ -11,7 +11,7 @@ from object_detection import runObjectDetection
 
 
 DOCUMENT_NOT_FOUND = {
-    "code": 404,
+    "code": 500,
     "body": {
         "error": "Failed to find document on the provided image"
     }

--- a/tasks/document-ocr-fn/resources/function/image_segmentation.py
+++ b/tasks/document-ocr-fn/resources/function/image_segmentation.py
@@ -16,13 +16,17 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
         contours, _ = cv2.findContours(mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
         if len(contours) == 0:
-            logging.error("Failed to find predicted mask")
+            logging.error("Failed to find document")
             return
 
         contour = max(contours, key = cv2.contourArea)
 
         epsilon = 0.02 * cv2.arcLength(contour, True)
         rectangle = cv2.approxPolyDP(contour, epsilon, True)
+
+        if rectangle.shape[0] < 4:
+            logging.error("Failed to find document")
+            return
 
         if rectangle.shape[0] > 4:
             rectangle = cv2.minAreaRect(contour)

--- a/tasks/document-ocr-fn/resources/function/image_segmentation.py
+++ b/tasks/document-ocr-fn/resources/function/image_segmentation.py
@@ -17,7 +17,7 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
 
         if len(contours) == 0:
             logging.error("Failed to find document")
-            return
+            return None
 
         contour = max(contours, key = cv2.contourArea)
 
@@ -26,7 +26,7 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
 
         if rectangle.shape[0] < 4:
             logging.error("Failed to find document")
-            return
+            return None
 
         if rectangle.shape[0] > 4:
             rectangle = cv2.minAreaRect(contour)

--- a/tasks/document-ocr/main.py
+++ b/tasks/document-ocr/main.py
@@ -30,6 +30,8 @@ def main() -> None:
         predictedMask = detect_document.run(segmentationModel, sample)
 
         mask = processMask(predictedMask)
+        if mask is None:
+            continue
 
         segmentedImage = segmentImage(sample.imagePath, mask)
         if segmentedImage is None:

--- a/tasks/document-ocr/src/image_segmentation.py
+++ b/tasks/document-ocr/src/image_segmentation.py
@@ -19,7 +19,7 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
 
         if len(contours) == 0:
             logging.error("Failed to find document")
-            return
+            return None
 
         contour = max(contours, key = cv2.contourArea)
 
@@ -28,7 +28,7 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
 
         if rectangle.shape[0] < 4:
             logging.error("Failed to find document")
-            return
+            return None
 
         if rectangle.shape[0] > 4:
             rectangle = cv2.minAreaRect(contour)

--- a/tasks/document-ocr/src/image_segmentation.py
+++ b/tasks/document-ocr/src/image_segmentation.py
@@ -18,13 +18,17 @@ def findRectangle(mask: np.ndarray) -> Optional[np.ndarray]:
         contours, _ = cv2.findContours(mask.astype(np.uint8), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
         if len(contours) == 0:
-            logging.error("Failed to find predicted mask")
+            logging.error("Failed to find document")
             return
 
         contour = max(contours, key = cv2.contourArea)
 
         epsilon = 0.02 * cv2.arcLength(contour, True)
         rectangle = cv2.approxPolyDP(contour, epsilon, True)
+
+        if rectangle.shape[0] < 4:
+            logging.error("Failed to find document")
+            return
 
         if rectangle.shape[0] > 4:
             rectangle = cv2.minAreaRect(contour)


### PR DESCRIPTION
Skip sample / return failed function request if detected document borders fail to represent a rectangle