### PR TITLE
Hotfix-qiime-pandas: Removed pandas from requirements.txt

### DIFF
--- a/tasks/qiime-alpha-beta-diversity/requirements.txt
+++ b/tasks/qiime-alpha-beta-diversity/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-dada2/requirements.txt
+++ b/tasks/qiime-dada2/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-demultiplexing/requirements.txt
+++ b/tasks/qiime-demultiplexing/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-import/requirements.txt
+++ b/tasks/qiime-import/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-otu-clustering/requirements.txt
+++ b/tasks/qiime-otu-clustering/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-taxonomic-analysis/requirements.txt
+++ b/tasks/qiime-taxonomic-analysis/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas

--- a/tasks/qiime-tree-phylogenetic-diversity-analysis/requirements.txt
+++ b/tasks/qiime-tree-phylogenetic-diversity-analysis/requirements.txt
@@ -1,4 +1,3 @@
 coretex
 py3nvml
 cchardet
-pandas


### PR DESCRIPTION
New version of pandas is not compatible with Qiime2 commands.
A specific version of pandas will be installed from the environment.yml file which is compatible with Qiime2 commands.