### PR TITLE
CTX-5257: Changed date_of_birth output to return object with numerical fields day, month and year

### DIFF
--- a/tasks/document-ocr-fn/resources/function/requirements.txt
+++ b/tasks/document-ocr-fn/resources/function/requirements.txt
@@ -13,9 +13,7 @@ seaborn>=0.11.0
 coremltools==6.3.0
 tensorflow==2.8
 tensorflowjs>=3.9.0
+transformers==4.36.2
+ultralytics==8.0.226
 thop
 coretex
-pytesseract
-easyocr
-transformers
-ultralytics


### PR DESCRIPTION
Changed document-ocr-fn's date_of_birth output to return object with numerical fields representing day, month and year