### PR TITLE
CTX-5322: Improved rectangle approximation in synthetic-document-generator

### DIFF
--- a/tasks/synthetic-document-generator/src/document_extractor.py
+++ b/tasks/synthetic-document-generator/src/document_extractor.py
@@ -27,7 +27,7 @@ def extractDocumentData(data: AnnotatedImageSampleData, classes: ImageDatasetCla
 
     documentClass = classes.classByLabel("document")
     if documentClass is None:
-        raise ValueError("Missing document class")
+        raise ValueError("Missing class: \"document\"")
 
     transformedInstances.append(CoretexSegmentationInstance.create(
         documentClass.classIds[0],

--- a/tasks/synthetic-document-generator/src/rect_extractor.py
+++ b/tasks/synthetic-document-generator/src/rect_extractor.py
@@ -23,17 +23,21 @@ def sortRectPoints(points: list[Point2D]) -> list[Point2D]:
     ]
 
 
+def calculateDistance(centroid: Point2D, point: Point2D) -> float:
+    return math.sqrt(math.pow(centroid.x - point.x, 2) + math.pow(centroid.y - point.y, 2))
+
+
 def reducePolygonTo4Points(points: list[Point2D]) -> list[Point2D]:
     xSum = sum([point.x for point in points])
     ySum = sum([point.y for point in points])
 
     centroid = Point2D(xSum / len(points), ySum / len(points))
 
-    # Calculate distance from centroid for each point
-    distances = [math.sqrt((centroid.x - point.x)**2 + (centroid.y - point.y)**2) for point in points]
+    distances = [(point, calculateDistance(centroid, point)) for point in points]
+    distances.sort(key = lambda x: x[1], reverse = True)
 
     # Return the four points furthest away from the centroid
-    return [points[index] for index, distance in sorted(enumerate(distances), key=lambda x: x[1], reverse=True)[:4]]
+    return [point for point, distance in distances[:4]]
 
 
 def extractRectangle(mask: np.ndarray) -> Rect:
@@ -50,7 +54,7 @@ def extractRectangle(mask: np.ndarray) -> Rect:
         points.append(Point2D(int(point[0][0]), int(point[0][1])))
 
     if len(points) < 4:
-        raise ValueError(f"Approximated polygon to less then four points ({len(points)})")
+        raise ValueError(f"Approximated polygon to less than four points ({len(points)})")
 
     if len(points) > 4:
         points = reducePolygonTo4Points(points)

--- a/tasks/synthetic-document-generator/src/rect_extractor.py
+++ b/tasks/synthetic-document-generator/src/rect_extractor.py
@@ -1,3 +1,5 @@
+import math
+
 import cv2
 import numpy as np
 
@@ -21,18 +23,38 @@ def sortRectPoints(points: list[Point2D]) -> list[Point2D]:
     ]
 
 
+def reducePolygonTo4Points(points: list[Point2D]) -> list[Point2D]:
+    xSum = sum([point.x for point in points])
+    ySum = sum([point.y for point in points])
+
+    centroid = Point2D(xSum / len(points), ySum / len(points))
+
+    # Calculate distance from centroid for each point
+    distances = [math.sqrt((centroid.x - point.x)**2 + (centroid.y - point.y)**2) for point in points]
+
+    # Return the four points furthest away from the centroid
+    return [points[index] for index, distance in sorted(enumerate(distances), key=lambda x: x[1], reverse=True)[:4]]
+
+
 def extractRectangle(mask: np.ndarray) -> Rect:
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
     if len(contours) != 1:
-        raise ValueError("Found more than one contour")
+        raise ValueError(f"Found more than one contour ({len(contours)})")
 
     epsilon = 0.02 * cv2.arcLength(contours[0], True)
-    rectangle = cv2.approxPolyDP(contours[0], epsilon, True)
+    approximatedPolygon = cv2.approxPolyDP(contours[0], epsilon, True)
 
     points: list[Point2D] = []
-    for point in rectangle:
+    for point in approximatedPolygon:
         points.append(Point2D(int(point[0][0]), int(point[0][1])))
 
+    if len(points) < 4:
+        raise ValueError(f"Approximated polygon to less then four points ({len(points)})")
+
+    if len(points) > 4:
+        points = reducePolygonTo4Points(points)
+
     points = sortRectPoints(points)
+
     return Rect(*points)

--- a/tasks/synthetic-document-generator/src/sample_generator.py
+++ b/tasks/synthetic-document-generator/src/sample_generator.py
@@ -42,7 +42,11 @@ def generateSample(
 ) -> tuple[Path, CoretexImageAnnotation]:
 
     data = sample.load()
-    documentImage, transformedAnnotation = document_extractor.extractDocumentData(data, classes)
+
+    try:
+        documentImage, transformedAnnotation = document_extractor.extractDocumentData(data, classes)
+    except ValueError as e:
+        raise ValueError(f"Could not generate image for sample \"{sample.name}\". Reason: {e}")
 
     pBackgroundImage = Image.fromarray(backgroundImage)
     pDocumentImage = Image.fromarray(documentImage)


### PR DESCRIPTION
Created additional polygon point count reduction for approximating the rectangle of the document annotations in synthetic-document-generator in case cv2.approxPolyDP does not return a quadrilateral.

This is done by using the four furthest away points from the centroid.